### PR TITLE
Feat: Shop CRUD 추가

### DIFF
--- a/src/main/java/com/example/workmate/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/workmate/config/WebSecurityConfig.java
@@ -46,13 +46,6 @@ public class WebSecurityConfig {
                                 // 권한 설정 필요
                                 .requestMatchers("/profile/{id}")
                                 .authenticated()
-//                                .hasAnyRole(Authority.ROLE_USER.getAuthority(), Authority.ROLE_BUSINESS_USER.getAuthority(), Authority.ROLE_ADMIN.getAuthority())
-                )
-                .formLogin(
-                        formLogin -> formLogin
-                                .loginPage("/account/login")
-                                .defaultSuccessUrl("/profile/{id}")
-                                .failureUrl("/account/login?fail")
                 )
                 .oauth2Login(oauth2Login -> oauth2Login
                         .loginPage("/account/login")

--- a/src/main/java/com/example/workmate/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/workmate/config/WebSecurityConfig.java
@@ -37,6 +37,7 @@ public class WebSecurityConfig {
 
                                 .requestMatchers(
                                         "/account/login",
+                                        "/account/register",
                                         "/account/users-register",
                                         "/account/business-register"
                                 )
@@ -44,13 +45,13 @@ public class WebSecurityConfig {
 
                                 // 권한 설정 필요
                                 .requestMatchers("/profile/{id}")
-                                .permitAll()
+                                .authenticated()
 //                                .hasAnyRole(Authority.ROLE_USER.getAuthority(), Authority.ROLE_BUSINESS_USER.getAuthority(), Authority.ROLE_ADMIN.getAuthority())
                 )
                 .formLogin(
                         formLogin -> formLogin
                                 .loginPage("/account/login")
-                                .defaultSuccessUrl("/account/my-profile")
+                                .defaultSuccessUrl("/profile/{id}")
                                 .failureUrl("/account/login?fail")
                 )
                 .oauth2Login(oauth2Login -> oauth2Login

--- a/src/main/java/com/example/workmate/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/workmate/config/WebSecurityConfig.java
@@ -46,6 +46,10 @@ public class WebSecurityConfig {
                                 // 권한 설정 필요
                                 .requestMatchers("/profile/{id}")
                                 .authenticated()
+
+                                // 매장 생성 테스트용
+                                .requestMatchers("/shop/**")
+                                .permitAll()
                 )
                 .oauth2Login(oauth2Login -> oauth2Login
                         .loginPage("/account/login")

--- a/src/main/java/com/example/workmate/controller/account/AccountController.java
+++ b/src/main/java/com/example/workmate/controller/account/AccountController.java
@@ -58,11 +58,13 @@ public class AccountController {
         log.info("password: {}", userDetails.getPassword());
 
         if (!passwordEncoder.matches(password, userDetails.getPassword())) {
+            log.error("비밀번호가 일치하지 않습니다.");
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
         }
 
         Account account = accountRepo.findByUsername(username)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        log.info("account Id: {}", account.getId());
 
         JwtResponseDto dto = new JwtResponseDto();
         dto.setToken(tokenUtils.generateToken(userDetails));

--- a/src/main/java/com/example/workmate/controller/account/AccountController.java
+++ b/src/main/java/com/example/workmate/controller/account/AccountController.java
@@ -70,7 +70,7 @@ public class AccountController {
         dto.setToken(tokenUtils.generateToken(userDetails));
         log.info("token: {}", dto.getToken());
 
-        return "redirect:/profile/"+account.getId();
+        return "redirect:/account/login";
     }
 
     // 회원가입 화면

--- a/src/main/java/com/example/workmate/controller/account/ProfileController.java
+++ b/src/main/java/com/example/workmate/controller/account/ProfileController.java
@@ -1,31 +1,24 @@
 package com.example.workmate.controller.account;
 
-import com.example.workmate.entity.account.Account;
-import com.example.workmate.repo.AccountRepo;
+import com.example.workmate.dto.account.AccountDto;
 import com.example.workmate.service.account.AccountService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@Controller
+@RestController
 @RequestMapping("/profile")
 @RequiredArgsConstructor
 public class ProfileController {
-    private final AccountService accountService;
-    private final AccountRepo accountRepo;
+    private final AccountService service;
 
-    // 사용자 프로필 페이지
-    @GetMapping("/{id}")
-    public String readOneAccount(@PathVariable("id") Long id) {
-        Account account = accountService.readOneAccount(id);
-
-        log.info(account.getName());
-        log.info(account.getAccountShops().toString());
-
-        return "my-profile";
+    // profile 정보 가져오기
+    @RequestMapping("/{id}")
+    public AccountDto readOneAccount(@PathVariable("id") Long id) {
+       return service.readOneAccount(id);
     }
 }
+

--- a/src/main/java/com/example/workmate/controller/account/ProfileController.java
+++ b/src/main/java/com/example/workmate/controller/account/ProfileController.java
@@ -1,24 +1,31 @@
 package com.example.workmate.controller.account;
 
-import com.example.workmate.dto.account.AccountDto;
+import com.example.workmate.entity.account.Account;
+import com.example.workmate.repo.AccountRepo;
 import com.example.workmate.service.account.AccountService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@RestController
+@Controller
 @RequestMapping("/profile")
 @RequiredArgsConstructor
 public class ProfileController {
     private final AccountService accountService;
+    private final AccountRepo accountRepo;
 
     // 사용자 프로필 페이지
     @GetMapping("/{id}")
-    public AccountDto readOneAccount(@PathVariable("id") Long id) {
-        return accountService.readOneAccount(id);
+    public String readOneAccount(@PathVariable("id") Long id) {
+        Account account = accountService.readOneAccount(id);
+
+        log.info(account.getName());
+        log.info(account.getAccountShops().toString());
+
+        return "my-profile";
     }
 }

--- a/src/main/java/com/example/workmate/controller/shop/ShopController.java
+++ b/src/main/java/com/example/workmate/controller/shop/ShopController.java
@@ -1,0 +1,54 @@
+package com.example.workmate.controller.shop;
+
+import com.example.workmate.dto.shop.ShopDto;
+import com.example.workmate.service.ShopService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/shop")
+@RequiredArgsConstructor
+public class ShopController {
+    private final ShopService service;
+
+    // CREATE Shop
+    @PostMapping("/create")
+    public ShopDto createShop(@RequestBody ShopDto dto) {
+        return service.createShop(dto);
+    }
+
+    // READ All Shop
+    @GetMapping("/read-all")
+    public List<ShopDto> readAllShop() {
+        return service.readAllShop();
+    }
+
+    // READ ONE Shop By ID
+    @GetMapping("/{id}")
+    public ShopDto readOneShop(@PathVariable("id") Long id) {
+        return service.readOneShop(id);
+    }
+
+    // READ ONE Shop By Name
+    @GetMapping("/read-one")
+    public ShopDto readOneShopByName(@RequestParam("name") String name) {
+        return service.readOneShopByName(name);
+    }
+
+    // UPDATE Shop
+    @PostMapping("/{id}/update")
+    public ShopDto updateShop(@PathVariable("id") Long id,@RequestBody ShopDto dto) {
+        return service.updateShop(id, dto);
+    }
+
+    // DELETE Shop
+    @DeleteMapping("/{id}/delete")
+    public String deleteShop(@PathVariable("id") Long id) {
+        service.deleteShop(id);
+        return "delete shop";
+    }
+}

--- a/src/main/java/com/example/workmate/dto/shop/ShopDto.java
+++ b/src/main/java/com/example/workmate/dto/shop/ShopDto.java
@@ -1,0 +1,28 @@
+package com.example.workmate.dto.shop;
+
+import com.example.workmate.entity.AccountShop;
+import com.example.workmate.entity.Shop;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ShopDto {
+    private Long id;
+    private String name;
+    private String address;
+    private List<AccountShop> accountShops;
+
+    public static ShopDto fromEntity(Shop shop) {
+        return ShopDto.builder()
+                .id(shop.getId())
+                .name(shop.getName())
+                .address(shop.getAddress())
+                .accountShops(shop.getAccountShops())
+                .build();
+    }
+}

--- a/src/main/java/com/example/workmate/entity/Shop.java
+++ b/src/main/java/com/example/workmate/entity/Shop.java
@@ -1,11 +1,7 @@
 package com.example.workmate.entity;
 
-import com.example.workmate.entity.account.Account;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -18,7 +14,9 @@ public class Shop {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Setter
     private String name;
+    @Setter
     private String address;
 
     @OneToMany(mappedBy = "shop")

--- a/src/main/java/com/example/workmate/repo/ShopRepo.java
+++ b/src/main/java/com/example/workmate/repo/ShopRepo.java
@@ -3,5 +3,8 @@ package com.example.workmate.repo;
 import com.example.workmate.entity.Shop;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ShopRepo extends JpaRepository<Shop, Long> {
+    Optional<Shop> findByNameContaining(String name);
 }

--- a/src/main/java/com/example/workmate/service/ShopService.java
+++ b/src/main/java/com/example/workmate/service/ShopService.java
@@ -1,0 +1,73 @@
+package com.example.workmate.service;
+
+import com.example.workmate.dto.shop.ShopDto;
+import com.example.workmate.entity.Shop;
+import com.example.workmate.facade.AuthenticationFacade;
+import com.example.workmate.repo.ShopRepo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ShopService {
+    private final ShopRepo shopRepo;
+    private final AuthenticationFacade authenticationFacade;
+
+    // CREATE Shop
+    public ShopDto createShop(ShopDto dto) {
+        Shop newShop = Shop.builder()
+                .name(dto.getName())
+                .address(dto.getAddress())
+                .build();
+
+        return ShopDto.fromEntity(shopRepo.save(newShop));
+    }
+
+    // READ All Shop
+    public List<ShopDto> readAllShop() {
+        List<Shop> shopList = shopRepo.findAll();
+        return shopList.stream()
+                .map(ShopDto::fromEntity)
+                .toList();
+    }
+
+    // READ ONE Shop by Id
+    public ShopDto readOneShop(Long id) {
+        Shop shop = shopRepo.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        return ShopDto.fromEntity(shop);
+    }
+
+    // READ ONE Shop by Name
+    public ShopDto readOneShopByName(String name) {
+        Shop shop = shopRepo.findByNameContaining(name)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        return ShopDto.fromEntity(shop);
+    }
+
+    // UPDATE Shop
+    public ShopDto updateShop(Long id, ShopDto dto) {
+        Shop target = shopRepo.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        target.setName(dto.getName());
+        target.setAddress(dto.getAddress());
+
+        return ShopDto.fromEntity(shopRepo.save(target));
+    }
+
+    // DELETE Shop
+    public void deleteShop(Long id) {
+        Shop target = shopRepo.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        shopRepo.delete(target);
+    }
+}

--- a/src/main/java/com/example/workmate/service/account/AccountService.java
+++ b/src/main/java/com/example/workmate/service/account/AccountService.java
@@ -1,5 +1,6 @@
 package com.example.workmate.service.account;
 
+import com.example.workmate.dto.account.AccountDto;
 import com.example.workmate.entity.account.Account;
 import com.example.workmate.facade.AuthenticationFacade;
 import com.example.workmate.repo.AccountRepo;
@@ -21,14 +22,31 @@ public class AccountService {
     private final AuthenticationFacade authFacade;
 
     // 유저 정보 가져오기
-    public Account readOneAccount(Long id) {
+    public AccountDto readOneAccount(Long id) {
+        Account account = getAccount(id);
+
+        log.info("auth user: {}", authFacade.getAuth().getName());
+        log.info("page username: {}", account.getUsername());
+
+        // 토큰으로 접근 시도한 유저와, 페이지의 유저가 다른경우 예외
+        if (authFacade.getAuth().getName().equals(account.getName())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
+        return AccountDto.fromEntity(account);
+    }
+
+    // 아르바이트 매장 추가하기
+
+
+    private Account getAccount(Long id) {
         Optional<Account> optionalAccount = accountRepo.findById(id);
         if (optionalAccount.isEmpty()) {
+            log.error("사용자를 찾을 수 없습니다.");
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        Account account = optionalAccount.get();
 
-        log.info(account.toString());
-        return account;
+        return optionalAccount.get();
     }
+
+
 }

--- a/src/main/java/com/example/workmate/service/account/AccountService.java
+++ b/src/main/java/com/example/workmate/service/account/AccountService.java
@@ -1,6 +1,5 @@
 package com.example.workmate.service.account;
 
-import com.example.workmate.dto.account.AccountDto;
 import com.example.workmate.entity.account.Account;
 import com.example.workmate.facade.AuthenticationFacade;
 import com.example.workmate.repo.AccountRepo;
@@ -21,15 +20,8 @@ public class AccountService {
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationFacade authFacade;
 
-    // 로그인
-    public boolean checkLogin(String username, String password) {
-        Account account = accountRepo.findByUsername(username)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        return account.getUsername().equals(username) && passwordEncoder.matches(password, account.getPassword());
-    }
-
     // 유저 정보 가져오기
-    public AccountDto readOneAccount(Long id) {
+    public Account readOneAccount(Long id) {
         Optional<Account> optionalAccount = accountRepo.findById(id);
         if (optionalAccount.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
@@ -37,6 +29,6 @@ public class AccountService {
         Account account = optionalAccount.get();
 
         log.info(account.toString());
-        return AccountDto.fromEntity(account);
+        return account;
     }
 }

--- a/src/main/java/com/example/workmate/service/account/JpaUserDetailsManger.java
+++ b/src/main/java/com/example/workmate/service/account/JpaUserDetailsManger.java
@@ -33,7 +33,6 @@ public class JpaUserDetailsManger implements UserDetailsManager {
         }
     }
 
-
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Optional<Account> optionalAccount = accountRepo.findByUsername(username);
@@ -54,6 +53,7 @@ public class JpaUserDetailsManger implements UserDetailsManager {
     @Override
     public void createUser(UserDetails user) {
         if (userExists(user.getUsername())) {
+            log.error("이미 존재하는 아이디입니다.");
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
         }
         if (user instanceof CustomAccountDetails accountDetails) {
@@ -66,6 +66,12 @@ public class JpaUserDetailsManger implements UserDetailsManager {
                     .authority(accountDetails.getAuthority())
                     .build();
             log.info("authority: {}", accountDetails.getAuthorities());
+
+            if (emailExists(newAccount.getEmail())) {
+                log.error("이미 존재하는 이메일입니다.");
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+            }
+
             accountRepo.save(newAccount);
         } else {
             throw new IllegalArgumentException("Unsupported UserDetails type");
@@ -89,5 +95,9 @@ public class JpaUserDetailsManger implements UserDetailsManager {
     @Override
     public boolean userExists(String username) {
         return accountRepo.existsByUsername(username);
+    }
+
+    public boolean emailExists(String email) {
+        return accountRepo.existsByEmail(email);
     }
 }

--- a/src/main/resources/templates/account/login-form.html
+++ b/src/main/resources/templates/account/login-form.html
@@ -41,6 +41,6 @@
         </div>
     </section>
 </main>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/main/resources/templates/my-profile.html
+++ b/src/main/resources/templates/my-profile.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:sec="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="UTF-8">
+    <title>Main</title>
+</head>
+<body>
+<h1>My Profile</h1>
+<h3>반갑습니다, <span sec:authentication="name"></span>님!</h3>
+<hr>
+
+
+<form action="/account/loggout">
+    <input type="submit" value="로그아웃">
+</form>
+</body>
+</html>


### PR DESCRIPTION
### 로그인 페이지
- 프론트에서 로그인 시도해도 로그인 되지 않음.. 프론트 확인하면서 오류 해결 필요함
- 대신 postman에서 회원가입 정보를 바탕으로 로그인 요청을 보내면, 콘솔에서 로그인 한 아이디와, 비밀번호, 유저의 Id, 발급된 토큰 정보를 확인 가능하게 설정함
- `/profile/{id}`
   - 해당 토큰 정보를 postman에 넣고 요청을 보내면 사용자의 정보가 제대로 나타나는 것을 확인 할 수 있음
  
### Shop CRUD 추가
 - 간단한 CRUD와 Shop이름으로 검색하는 과정만 추가됨